### PR TITLE
Support gui_qt (same pattern as gui_gtk)

### DIFF
--- a/plugin/fontzoom.vim
+++ b/plugin/fontzoom.vim
@@ -43,11 +43,11 @@ endfunction
 if !exists('g:fontzoom_pattern')
   " TODO: X11 is not tested because I do not have the environment.
   let g:fontzoom_pattern =
-  \   has('win32') || has('win64') ||
-  \   has('mac') || has('macunix') ? ':h\zs\d\+':
-  \   has('gui_gtk')               ? '\s\+\zs\d\+$':
-  \   has('X11')                   ? '\v%([^-]*-){6}\zs\d+\ze%(-[^-]*){7}':
-  \                                  '*Unknown system*'
+  \   has('win32')   || has('win64') ||
+  \   has('mac')     || has('macunix') ? ':h\zs\d\+':
+  \   has('gui_gtk') || has('gui_qt')  ? '\s\+\zs\d\+$':
+  \   has('X11')                       ? '\v%([^-]*-){6}\zs\d+\ze%(-[^-]*){7}':
+  \                                      '*Unknown system*'
 endif
 
 


### PR DESCRIPTION
Hi.

I've added a condition to check for has('gui_qt'), since that GUI version also uses the same pattern as Vim-GTK. I've updated the aligment of the code in the change, too. Sorry if that makes the diff less clear. I thought you would prefer it this way.

Thanks a lot for this simple but useful plugin. :-)
